### PR TITLE
Feat/atualizar pessoa

### DIFF
--- a/src/main/java/com/db/crud_pessoas/api/controller/PessoaController.java
+++ b/src/main/java/com/db/crud_pessoas/api/controller/PessoaController.java
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.db.crud_pessoas.api.dto.PessoaDTO;
 import com.db.crud_pessoas.api.dto.request.pessoa.PessoaRequisicaoDTO;
 import com.db.crud_pessoas.domain.service.interfaces.IPessoaService;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
 
 @RequestMapping("/api/usuarios")
 @RestController
@@ -33,6 +36,12 @@ public class PessoaController {
     public ResponseEntity<PessoaDTO> cadastrarPessoa(@RequestBody PessoaRequisicaoDTO requisicao) {
         PessoaDTO pessoaDTO = pessoaService.criarPessoa(requisicao);
         return ResponseEntity.status(201).body(pessoaDTO);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PessoaDTO> atualizarPessoa(@PathVariable Long id, @RequestBody PessoaRequisicaoDTO requisicao) {
+        PessoaDTO pessoaDTO = pessoaService.atualizarPessoa(id, requisicao); 
+        return ResponseEntity.ok().body(pessoaDTO);
     }
     
 }

--- a/src/main/java/com/db/crud_pessoas/domain/service/PessoaService.java
+++ b/src/main/java/com/db/crud_pessoas/domain/service/PessoaService.java
@@ -6,12 +6,15 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import com.db.crud_pessoas.api.dto.PessoaDTO;
+import com.db.crud_pessoas.api.dto.request.endereco.EnderecoRequisicaoDTO;
 import com.db.crud_pessoas.api.dto.request.pessoa.PessoaRequisicaoDTO;
 import com.db.crud_pessoas.domain.entity.Endereco;
 import com.db.crud_pessoas.domain.entity.Pessoa;
 import com.db.crud_pessoas.domain.repository.EnderecoRepository;
 import com.db.crud_pessoas.domain.repository.PessoaRepository;
 import com.db.crud_pessoas.domain.service.interfaces.IPessoaService;
+
+import jakarta.persistence.EntityNotFoundException;
 
 @Service
 public class PessoaService implements IPessoaService {
@@ -41,19 +44,8 @@ public class PessoaService implements IPessoaService {
         Pessoa pessoaSalva = pessoaRepository.save(pessoaASerSalva);
         
         if (pessoaDTO.getEnderecos() != null) {
-            List<Endereco> enderecos = pessoaDTO.getEnderecos().stream()
-                .map(enderecoDTO -> {
-                    Endereco endereco = new Endereco();
-                    endereco.setRua(enderecoDTO.getRua());
-                    endereco.setNumero(enderecoDTO.getNumero());
-                    endereco.setBairro(enderecoDTO.getBairro());
-                    endereco.setCidade(enderecoDTO.getCidade());
-                    endereco.setEstado(enderecoDTO.getEstado());
-                    endereco.setCep(enderecoDTO.getCep());
-                    endereco.setPessoa(pessoaSalva);
-                    return endereco;
-                })
-                .collect(Collectors.toList());
+            List<EnderecoRequisicaoDTO> enderecosDTO = pessoaDTO.getEnderecos();
+            List<Endereco> enderecos = converterListaEnderecoDeDTOParaDominio(enderecosDTO, pessoaSalva);
             
             enderecos = enderecoRepository.saveAll(enderecos);
             
@@ -63,9 +55,32 @@ public class PessoaService implements IPessoaService {
         return new PessoaDTO(pessoaSalva);
     }
 
-    public PessoaDTO atualizarPessoa(Long id, PessoaRequisicaoDTO pessoa) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'atualizarPessoa'");
+    public PessoaDTO atualizarPessoa(Long id, PessoaRequisicaoDTO pessoaRequisicaoDTO) {
+        Pessoa pessoa = pessoaRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("Pessoa não encontrada com o id " + id));
+        if (pessoaRequisicaoDTO.getNome() != null) {
+            pessoa.setNome(pessoaRequisicaoDTO.getNome());
+        }
+        if (pessoaRequisicaoDTO.getCpf() != null) {
+            pessoa.setCpf(pessoaRequisicaoDTO.getCpf());
+        }
+        if (pessoaRequisicaoDTO.getDataDeNascimento() != null) {
+            pessoa.setDataDeNascimento(pessoaRequisicaoDTO.getDataDeNascimento());
+        }
+        if (pessoaRequisicaoDTO.getEnderecos() != null) {
+            enderecoRepository.deleteAll(pessoa.getEnderecos());
+            
+            List<Endereco> novosEnderecos = converterListaEnderecoDeDTOParaDominio(
+                pessoaRequisicaoDTO.getEnderecos(), 
+                pessoa
+            );
+            
+            novosEnderecos = enderecoRepository.saveAll(novosEnderecos);
+            pessoa.setEnderecos(novosEnderecos);
+        }
+
+        Pessoa pessoaAtualizada = pessoaRepository.save(pessoa);
+        
+        return new PessoaDTO(pessoaAtualizada);
     }
 
     public void excluirPessoa(Long id) {
@@ -75,6 +90,22 @@ public class PessoaService implements IPessoaService {
 
     private List<PessoaDTO> converterListaDeDominioParaDTO(List<Pessoa> listaPessoas) {
         return listaPessoas.stream().map(PessoaDTO::new).collect(Collectors.toList());
+    }
+
+    private List<Endereco> converterListaEnderecoDeDTOParaDominio(List<EnderecoRequisicaoDTO> listaEnderecos, Pessoa pessoa) {
+        return listaEnderecos.stream()
+                .map(enderecoDTO -> {
+                    Endereco endereco = new Endereco();
+                    endereco.setRua(enderecoDTO.getRua());
+                    endereco.setNumero(enderecoDTO.getNumero());
+                    endereco.setBairro(enderecoDTO.getBairro());
+                    endereco.setCidade(enderecoDTO.getCidade());
+                    endereco.setEstado(enderecoDTO.getEstado());
+                    endereco.setCep(enderecoDTO.getCep());
+                    endereco.setPessoa(pessoa);
+                    return endereco;
+                })
+                .collect(Collectors.toList());
     }
 
     private void validarCadastroDTO(PessoaRequisicaoDTO requisicaoDTO) {

--- a/src/main/java/com/db/crud_pessoas/domain/service/PessoaService.java
+++ b/src/main/java/com/db/crud_pessoas/domain/service/PessoaService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.db.crud_pessoas.api.dto.PessoaDTO;
 import com.db.crud_pessoas.api.dto.request.endereco.EnderecoRequisicaoDTO;
@@ -55,6 +56,7 @@ public class PessoaService implements IPessoaService {
         return new PessoaDTO(pessoaSalva);
     }
 
+    @Transactional
     public PessoaDTO atualizarPessoa(Long id, PessoaRequisicaoDTO pessoaRequisicaoDTO) {
         Pessoa pessoa = pessoaRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("Pessoa não encontrada com o id " + id));
         if (pessoaRequisicaoDTO.getNome() != null) {
@@ -79,7 +81,7 @@ public class PessoaService implements IPessoaService {
         }
 
         Pessoa pessoaAtualizada = pessoaRepository.save(pessoa);
-        
+
         return new PessoaDTO(pessoaAtualizada);
     }
 

--- a/src/test/java/com/db/crud_pessoas/api/controller/PessoaControllerTest.java
+++ b/src/test/java/com/db/crud_pessoas/api/controller/PessoaControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -143,6 +144,37 @@ public class PessoaControllerTest {
         Exception exception = assertThrows(IllegalArgumentException.class, 
             () -> pessoaController.cadastrarPessoa(requisicao));
         assertEquals("Dados inválidos", exception.getMessage());
+    }
+
+    @Test
+    void deveAtualizarPessoaComSucesso() {
+        PessoaRequisicaoDTO requisicao = criarPessoaRequisicaoDTO();
+        PessoaDTO pessoaRetornada = criarPessoaDTO();
+        final Long idASerBuscado = 1L;
+        
+        when(pessoaService.atualizarPessoa(anyLong(), any(PessoaRequisicaoDTO.class)))
+            .thenReturn(pessoaRetornada);
+
+        ResponseEntity<PessoaDTO> resposta = pessoaController.atualizarPessoa(idASerBuscado, requisicao);
+
+        assertNotNull(resposta);
+        assertEquals(200, resposta.getStatusCode().value());
+        assertEquals(pessoaRetornada.getId(), resposta.getBody().getId());
+        assertEquals(pessoaRetornada.getNome(), resposta.getBody().getNome());
+        verify(pessoaService, times(1)).atualizarPessoa(anyLong(), any(PessoaRequisicaoDTO.class));
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoIDNaoExistirEmBanco() {
+        PessoaRequisicaoDTO requisicao = new PessoaRequisicaoDTO();
+        final Long idASerBuscado = 1L;
+
+        when(pessoaService.atualizarPessoa(anyLong(), any(PessoaRequisicaoDTO.class)))
+            .thenThrow(new IllegalArgumentException("Pessoa não encontrada com o id " + 1L));
+
+        Exception exception = assertThrows(IllegalArgumentException.class, 
+            () -> pessoaController.atualizarPessoa(idASerBuscado, requisicao));
+        assertEquals("Pessoa não encontrada com o id 1", exception.getMessage());
     }
 
     private PessoaRequisicaoDTO criarPessoaRequisicaoDTO() {


### PR DESCRIPTION
### ✨ Descrição do PR

Este PR adiciona a feature de **atualizar pessoas cadastradas no sistema pelo ID**, juntamente com seus respectivos **endereços**. Além disso, foram incluídos os testes **unitários** correspondentes.  

---

### 📘 Endpoint disponível

- **PUT** `/api/usuarios/{ID}`  
  Retorna uma ResponseEntity com um DTO em formato JSON do objeto atualizado, em caso de sucesso.

**GET - Estado do Objeto antes da operação**

![image](https://github.com/user-attachments/assets/acbf903c-7d3b-4d90-b1fb-b5ed0a454195)

**PUT - Body JSON de campos que desejo alteração:**

![image](https://github.com/user-attachments/assets/18f962bb-5087-4cdc-b5da-9a999c76d335)

**PUT - Response JSON:**

![image](https://github.com/user-attachments/assets/d51006a7-559a-44b9-9256-d6a3d103a6b0)

**GET - Estado do Objeto após a operação**

![image](https://github.com/user-attachments/assets/9f952e70-c571-40d6-b75c-2b105eb8f489)


---

### ✅ Testes incluídos

**Unitários**:
- `PessoaControllerTest.java`
- `PessoaServiceTest.java`

---

### 👀  Observações:

Como trabalhamos com endereços que podem ser alterados, para não termos um monte de dados mortos de endereços dentro do nosso banco de dados, optei por sempre que houver uma atualização de endereço o sistema apagar todos os dados de endereços antigos relacionados aquele usuário e criar novos endereços a partir dos dados inseridos (atualizados).

---

### 📦  Issue referenciada: [Atualizar os dados de uma pessoa #3](https://github.com/lucasdemattos8/desafio-crud-pessoas/issues/3)