### PR TITLE
Feat/deletar pessoa

### DIFF
--- a/src/main/java/com/db/crud_pessoas/api/controller/PessoaController.java
+++ b/src/main/java/com/db/crud_pessoas/api/controller/PessoaController.java
@@ -3,6 +3,7 @@ package com.db.crud_pessoas.api.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,6 +43,12 @@ public class PessoaController {
     public ResponseEntity<PessoaDTO> atualizarPessoa(@PathVariable Long id, @RequestBody PessoaRequisicaoDTO requisicao) {
         PessoaDTO pessoaDTO = pessoaService.atualizarPessoa(id, requisicao); 
         return ResponseEntity.ok().body(pessoaDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deletarPessoa(@PathVariable Long id) {
+        pessoaService.excluirPessoa(id); 
+        return ResponseEntity.noContent().build();
     }
     
 }

--- a/src/main/java/com/db/crud_pessoas/domain/service/PessoaService.java
+++ b/src/main/java/com/db/crud_pessoas/domain/service/PessoaService.java
@@ -85,9 +85,12 @@ public class PessoaService implements IPessoaService {
         return new PessoaDTO(pessoaAtualizada);
     }
 
+    @Transactional
     public void excluirPessoa(Long id) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'excluirPessoa'");
+        if (!pessoaRepository.existsById(id)) {
+            throw new EntityNotFoundException("Pessoa não encontrada com o id " + id);
+        }
+        pessoaRepository.deleteById(id);
     }
 
     private List<PessoaDTO> converterListaDeDominioParaDTO(List<Pessoa> listaPessoas) {

--- a/src/test/java/com/db/crud_pessoas/domain/service/PessoaServiceJavaTest.java
+++ b/src/test/java/com/db/crud_pessoas/domain/service/PessoaServiceJavaTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -225,7 +228,7 @@ public class PessoaServiceJavaTest {
     }
 
     @Test
-    void deveLancarExcecaoQuandoPessoaNaoEncontrada() {
+    void naoDeveAtualizarQuandoPessoaNaoEncontrada() {
         Long id = 1L;
         when(pessoaRepository.findById(id)).thenReturn(Optional.empty());
         
@@ -294,6 +297,32 @@ public class PessoaServiceJavaTest {
         assertNotNull(resultado);
         assertEquals("Nome Original", resultado.getNome());
         assertEquals("12345678900", resultado.getCpf());
+    }
+
+    @Test
+    void deveExcluirPessoaQuandoExistir() {
+        Long id = 1L;
+        when(pessoaRepository.existsById(id)).thenReturn(true);
+        doNothing().when(pessoaRepository).deleteById(id);
+
+        pessoaService.excluirPessoa(id);
+
+        verify(pessoaRepository).existsById(id);
+        verify(pessoaRepository).deleteById(id);
+    }
+
+    @Test
+    void naoDeveDeletarQuandoPessoaNaoEncontrada() {
+        Long pessoaASerDeletadaID = 1L;
+        when(pessoaRepository.existsById(pessoaASerDeletadaID)).thenReturn(false);
+
+        Exception exceptionResposta = assertThrows(
+            EntityNotFoundException.class,
+            () -> pessoaService.excluirPessoa(pessoaASerDeletadaID));
+        
+        assertEquals("Pessoa não encontrada com o id " + pessoaASerDeletadaID, exceptionResposta.getMessage());
+        verify(pessoaRepository).existsById(pessoaASerDeletadaID);
+        verify(pessoaRepository, never()).deleteById(anyLong());
     }
 
     private PessoaRequisicaoDTO criarPessoaRequisicaoDTO() {


### PR DESCRIPTION
### ✨ Descrição do PR

Este PR adiciona a feature de **deleção de pessoas cadastradas no sistema pelo ID**, juntamente com seus respectivos **endereço em casacata**. Além disso, foram incluídos os testes **unitários** correspondentes.  

---

### 📘 Endpoint disponível

- **DELETE** `/api/usuarios/{ID}`  
  Retorna uma ResponseEntity com corpo vázio e status code de 204

---
### 📘 Endpoint Demonstração

**GET - Estado do Objeto antes da operação**

![image](https://github.com/user-attachments/assets/07aecf5c-a364-40cb-9e0d-3f282753c924)

**DELETE - Estado do Objeto antes da operação**
![image](https://github.com/user-attachments/assets/b9900783-2fc8-4d14-8f81-858c8d29c60a)

**GET - Estado do Objeto pós a operação**
![image](https://github.com/user-attachments/assets/4a6b54f1-794f-4c08-96e0-5d1995c184c4)

**DB - Tabela de endereços:**
![image](https://github.com/user-attachments/assets/42d9ac84-58c5-4729-8e0c-e5d257ef8a69)


---

### ✅ Testes incluídos

**Unitários**:
- `PessoaControllerTest.java`
- `PessoaServiceTest.java`

---

### 👀  Observações:

N/A

---

### 📦  Issue referenciada: [Excluir uma pessoa #4](https://github.com/lucasdemattos8/desafio-crud-pessoas/issues/4)