### PR TITLE
Mostrar a idade da pessoa

### DIFF
--- a/src/main/java/com/db/crud_pessoas/api/dto/PessoaDTO.java
+++ b/src/main/java/com/db/crud_pessoas/api/dto/PessoaDTO.java
@@ -1,6 +1,7 @@
 package com.db.crud_pessoas.api.dto;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,6 +15,7 @@ public class PessoaDTO {
     private Long id;
     private String nome;
     private LocalDate dataDeNascimento;
+    private int idade;
     private String cpf;
     private List<EnderecoResumoDTO> enderecos;
 
@@ -26,6 +28,7 @@ public class PessoaDTO {
         this.dataDeNascimento = pessoa.getDataDeNascimento();
         this.cpf = pessoa.getCpf();
         this.enderecos = toEnderecosResumoDTO(pessoa.getEnderecos());
+        this.idade = calcularIdade();
     }
     
     public Long getId() {
@@ -52,6 +55,14 @@ public class PessoaDTO {
         this.dataDeNascimento = dataDeNascimento;
     }
 
+    public int getIdade() {
+        return idade;
+    }
+
+    public void setIdade(int idade) {
+        this.idade = idade;
+    }
+
     public String getCpf() {
         return cpf;
     }
@@ -66,6 +77,13 @@ public class PessoaDTO {
 
     public void setEnderecos(List<EnderecoResumoDTO> enderecos) {
         this.enderecos = enderecos;
+    }
+
+    private int calcularIdade() {
+        if (dataDeNascimento == null) {
+            return 0;
+        }
+        return Period.between(dataDeNascimento, LocalDate.now()).getYears();
     }
 
     private static List<EnderecoResumoDTO> toEnderecosResumoDTO(List<Endereco> enderecos) {

--- a/src/test/java/com/db/crud_pessoas/api/controller/PessoaControllerTest.java
+++ b/src/test/java/com/db/crud_pessoas/api/controller/PessoaControllerTest.java
@@ -133,10 +133,13 @@ public class PessoaControllerTest {
 
         ResponseEntity<PessoaDTO> resposta = pessoaController.cadastrarPessoa(requisicao);
 
+        final int idadeEsperada = 35;
+
         assertNotNull(resposta);
         assertEquals(201, resposta.getStatusCode().value());
         assertEquals(pessoaRetornada.getId(), resposta.getBody().getId());
         assertEquals(pessoaRetornada.getNome(), resposta.getBody().getNome());
+        assertEquals(idadeEsperada, resposta.getBody().getIdade());
         verify(pessoaService, times(1)).criarPessoa(any(PessoaRequisicaoDTO.class));
     }
 


### PR DESCRIPTION
### ✨ Descrição do PR

Este PR adiciona a feature de dentro do **DTO de Pessoa** ser exibido a idade da pessoa baseada na data atual do dia que está sendo buscado.

É um dado que é informado nos DTOs, mas não é persistida em banco.

---

### 📘 Endpoint disponível

Todos os endpoints de `/api/usuarios` que tem um retorno de DTO vai ter essa feature disponibilizada.
**GET, POST, PUT**

---
### 📘 Endpoint Demonstração

**GET - Estado do Objeto**

![image](https://github.com/user-attachments/assets/e6ce3d48-f1a3-427c-b5b9-96a831d46521)

**Banco - Demonstrando que não é persistido**

![image](https://github.com/user-attachments/assets/ae9d3a9a-8842-448a-a669-88be3c68e139)


---

### ✅ Testes incluídos

**Unitários**:
- `PessoaControllerTest.java`
- `PessoaServiceTest.java`

---

### 👀  Observações:

N/A

---

### 📦  Issue referenciada: [Mostrar a idade da pessoa #5](https://github.com/lucasdemattos8/desafio-crud-pessoas/issues/5)